### PR TITLE
added code to prevent white outline after holding down shift button

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,8 +3,23 @@ import AppBar from './components/AppBar';
 import { ThemeProvider } from './components/ThemeProvider';
 import { Toaster } from './components/ui/toaster';
 import Routes from './routes';
+import { useEffect } from 'react';
 
 function App() {
+    useEffect(() => {
+        const handleClick = (e: MouseEvent) => {
+            if (e.shiftKey) {
+                e.preventDefault(); // Prevents shift-click from focusing elements
+            }
+        };
+
+        document.addEventListener('click', handleClick);
+
+        return () => {
+            document.removeEventListener('click', handleClick); // Clean up
+        };
+    }, []);
+
     return (
         <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
             <TooltipProvider>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Elements should not be outlined in white anymore after shift button is held down.
### The purpose of this pull request is to fix this bug.

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [X] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
